### PR TITLE
When constructing a trade, use WETH with chain id

### DIFF
--- a/src/pages/docs/v2/05-javascript-SDK/04-trading.md
+++ b/src/pages/docs/v2/05-javascript-SDK/04-trading.md
@@ -52,7 +52,7 @@ import { Percent } from '@uniswap/sdk'
 const slippageTolerance = new Percent('50', '10000') // 50 bips, or 0.50%
 
 const amountOutMin = trade.minimumAmountOut(slippageTolerance).raw // needs to be converted to e.g. hex
-const path = [WETH.address, DAI.address]
+const path = [WETH[DAI.chainId].address, DAI.address]
 const to = '' // should be a checksummed recipient address
 const deadline = Math.floor(Date.now() / 1000) + 60 * 20 // 20 minutes from the current Unix time
 const value = trade.inputAmount.raw // // needs to be converted to e.g. hex

--- a/src/pages/docs/v2/05-javascript-SDK/04-trading.md
+++ b/src/pages/docs/v2/05-javascript-SDK/04-trading.md
@@ -26,7 +26,7 @@ const route = new Route([pair], WETH[DAI.chainId])
 
 const amountIn = '1000000000000000000' // 1 WETH
 
-const trade = new Trade(route, new TokenAmount(WETH, amountIn), TradeType.EXACT_INPUT)
+const trade = new Trade(route, new TokenAmount(WETH[DAI.chainId], amountIn), TradeType.EXACT_INPUT)
 ```
 
 So, we've constructed a trade entity, but how do we use it to actually send a transaction? There are still a few pieces we need to put in place.


### PR DESCRIPTION
const trade = new Trade(route, new TokenAmount(WETH, amountIn), TradeType.EXACT_INPUT)
does not work, it throws an error "TypeError: Cannot convert undefined to a BigInt".
WETH should be replaced with WETH[DAI.chainId] to indicate the specific WETH token we are interested in.