### PR TITLE
Fix most broken links

### DIFF
--- a/src/pages/blog/02-uniswap-info/index.md
+++ b/src/pages/blog/02-uniswap-info/index.md
@@ -36,7 +36,7 @@ Using a [app.uniswap.org](http://app.uniswap.org) iFrame integration, you can no
 
 Uniswap.info automatically shows all tokens on the Uniswap protocol as long as there is at least 0.1 ETH in liquidity. This means it can be used to trade tokens that are not shown on the default list of app.uniswap.org. We highly recommend you verify the address of any tokens traded.
 
-_If you’re interested in doing something similar on your site, you can [read more](https://docs.uniswap.io/frontend-integration/iframe) about how to embed app.uniswap.org)_
+_If you’re interested in doing something similar on your site, you can [read more](https://uniswap.org/docs/v2/interface-integration/iframe-integration/) about how to embed app.uniswap.org)_
 
 # Linking
 

--- a/src/pages/blog/04-uniswap-v2/index.md
+++ b/src/pages/blog/04-uniswap-v2/index.md
@@ -147,7 +147,7 @@ While this is a huge improvement, there are some new smart contract patterns int
 - Core no longer returns the maximum number of ERC20 tokens for a given input amount. Instead, a router must specify the number of ERC20 tokens it wants. Core will send this number as long as the invariant is preserved after taking 0.3% off any input amount.
 - Routers should handle logic around slippage safety checks and multihop trades.
 
-For additional details please read the <Link to='/docs/v2/smart-contracts/architecture/'>architecture section</Link> of the in-progress Uniswap V2 docs or the core and periphery smart contracts themselves.
+For additional details please read the <Link to='/docs/v2/protocol-overview/smart-contracts/'>architecture section</Link> of the in-progress Uniswap V2 docs or the core and periphery smart contracts themselves.
 
 ## Technical Improvements
 
@@ -202,7 +202,7 @@ In the meantime, developers can begin playing with Uniswap V2 today! The factory
 
 **<Link to='/docs/v2/smart-contracts/factory/#address'>Uniswap V2 Factory (Testnet)</Link>**
 
-**<Link to='/docs/v2/smart-contracts/router/#address'>Uniswap V2 Router 01 (Testnet)</Link>**
+**<Link to='/docs/v2/smart-contracts/router01/#address'>Uniswap V2 Router 01 (Testnet)</Link>**
 
 **We want to hear from you!**
 

--- a/src/pages/docs/v1/01-frontend-integration/02-pool-liquidity.md
+++ b/src/pages/docs/v1/01-frontend-integration/02-pool-liquidity.md
@@ -21,7 +21,7 @@ The `createExchange` function is used to deploy exchange contracts for ERC20 tok
 factory.methods.createExchange(tokenAddress).send()
 ```
 
-Once an exchange is created the address can be retrieved with [`getExchange`](connect-to-uniswap.md#get-exchange-address).
+Once an exchange is created the address can be retrieved with [`getExchange`](../connect-to-uniswap/#get-exchange-address).
 
 ## Exchange Reserves
 

--- a/src/pages/docs/v2/01-protocol-overview/01-how-uniswap-works.md
+++ b/src/pages/docs/v2/01-protocol-overview/01-how-uniswap-works.md
@@ -5,7 +5,7 @@ tags: protocol-overview, documentation
 
 ![](/images/anatomy.jpg)
 
-Uniswap is an _automated liquidity protocol_ powered by a <Link to="/docs/v2/core-concepts/math">constant product formula</Link> and implemented in a system of non-upgradeable smart contracts on the [Ethereum](https://ethereum.org/) blockchain. It obviates the need for trusted intermediaries, prioritizing **decentralization**, **censorship resistance**, and **security**. Uniswap is **open-source software** licensed under the [GPL](https://en.wikipedia.org/wiki/GNU_General_Public_License).
+Uniswap is an _automated liquidity protocol_ powered by a <Link to="/docs/v2/advanced-topics/math/">constant product formula</Link> and implemented in a system of non-upgradeable smart contracts on the [Ethereum](https://ethereum.org/) blockchain. It obviates the need for trusted intermediaries, prioritizing **decentralization**, **censorship resistance**, and **security**. Uniswap is **open-source software** licensed under the [GPL](https://en.wikipedia.org/wiki/GNU_General_Public_License).
 
 Each Uniswap smart contract, or pair, manages a liquidity pool made up of reserves of two [ERC-20](https://eips.ethereum.org/EIPS/eip-20) tokens.
 

--- a/src/pages/docs/v2/03-advanced-topics/01-fees.md
+++ b/src/pages/docs/v2/03-advanced-topics/01-fees.md
@@ -11,7 +11,7 @@ Swapping fees are immediately deposited into liquidity reserves. This increases 
 
 Since fees are added to liquidity pools, the invariant increases at the end of every trade. Within a single transaction, the invariant represents `token0_pool / token1_pool` at the end of the previous transaction.
 
-There are many community developed tools to determine returns. You can also read more in the docs about how to think about [LP returns](/docs/v2/advanced-topics/returns/).
+There are many community developed tools to determine returns. You can also read more in the docs about how to think about [LP returns](/docs/v2/advanced-topics/understanding-returns/).
 
 ## Protocol Fees
 

--- a/src/pages/docs/v2/03-advanced-topics/02-pricing.md
+++ b/src/pages/docs/v2/03-advanced-topics/02-pricing.md
@@ -25,11 +25,11 @@ There are, of course, other options for oracles, including <Link to='/docs/v2/co
 
 ## Exact Input
 
-If you'd like to send an exact amount of input tokens in exchange for as many output tokens as possible, you'll want to use <Link to='/docs/v2/smart-contracts/router02/#getamountsout'>getAmountsOut</Link>. The equivalent SDK function is <Link to='/docs/v2/sdk/pair/#getoutputamount'>getOutputAmount</Link>, or <Link to='/docs/v2/sdk/trade/#minimumamountout'>minimumAmountOut</Link> for slippage calculations.
+If you'd like to send an exact amount of input tokens in exchange for as many output tokens as possible, you'll want to use <Link to='/docs/v2/smart-contracts/router02/#getamountsout'>getAmountsOut</Link>. The equivalent SDK function is <Link to='/docs/v2/SDK/pair/#getoutputamount'>getOutputAmount</Link>, or <Link to='/docs/v2/SDK/trade/#minimumamountout-since-204'>minimumAmountOut</Link> for slippage calculations.
 
 ## Exact Output
 
-If you'd like to receive an exact amount of output tokens for as few input tokens as possible, you'll want to use <Link to='/docs/v2/smart-contracts/router02/#getamountsin'>getAmountsIn</Link>. The equivalent SDK function is <Link to='/docs/v2/sdk/pair/#getinputamount'>getInputAmount</Link>, or <Link to='/docs/v2/sdk/trade/#maximumamountin'>maximumAmountIn</Link> for slippage calculations.
+If you'd like to receive an exact amount of output tokens for as few input tokens as possible, you'll want to use <Link to='/docs/v2/smart-contracts/router02/#getamountsin'>getAmountsIn</Link>. The equivalent SDK function is <Link to='/docs/v2/SDK/pair/#getinputamount'>getInputAmount</Link>, or <Link to='/docs/v2/SDK/trade/#maximumamountin-since-204'>maximumAmountIn</Link> for slippage calculations.
 
 ## Swap to Price
 

--- a/src/pages/docs/v2/09-smart-contracts/01-factory.md
+++ b/src/pages/docs/v2/09-smart-contracts/01-factory.md
@@ -61,7 +61,7 @@ Returns the total number of pairs created through the factory so far.
 function feeTo() external view returns (address);
 ```
 
-See <Link to='/docs/v2/smart-contracts/architecture/#protocol-charge-calculation'>Protocol Charge Calculation</Link>.
+See <Link to='/docs/v2/advanced-topics/fees/#protocol-charge-calculation'>Protocol Charge Calculation</Link>.
 
 ## feeToSetter
 

--- a/src/pages/docs/v2/09-smart-contracts/02-pair.md
+++ b/src/pages/docs/v2/09-smart-contracts/02-pair.md
@@ -62,7 +62,7 @@ Emitted each time reserves are updated via [mint](#mint-1), [burn](#burn-1), [sw
 function MINIMUM_LIQUIDITY() external pure returns (uint);
 ```
 
-Returns `1000` for all pairs. See <Link to='/docs/v2/smart-contracts/architecture/#minimum-liquidity'>Minimum Liquidity</Link>.
+Returns `1000` for all pairs. See <Link to='/docs/v2/protocol-overview/smart-contracts/#minimum-liquidity'>Minimum Liquidity</Link>.
 
 ## factory
 
@@ -148,7 +148,7 @@ Destroys pool tokens.
 function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
 ```
 
-Swaps tokens. For regular swaps, `data.length` must be `0`. Also see <Link to='/docs/v2/guides/flash-swaps'>Flash Swaps</Link>.
+Swaps tokens. For regular swaps, `data.length` must be `0`. Also see <Link to='/docs/v2/core-concepts/flash-swaps/'>Flash Swaps</Link>.
 
 - Emits [Swap](#swap), [Sync](#sync).
 

--- a/src/pages/docs/v2/09-smart-contracts/03-pair-erc-20.md
+++ b/src/pages/docs/v2/09-smart-contracts/03-pair-erc-20.md
@@ -25,7 +25,7 @@ Emitted each time an approval occurs via [approve](#approve) or [permit](#permit
 event Transfer(address indexed from, address indexed to, uint value);
 ```
 
-Emitted each time a transfer occurs via [transfer](#transfer-1), [transferFrom](#transferfrom), <Link to='/docs/v2/smart-contracts/exchange#mint-1'>mint</Link>, or <Link to='/docs/v2/smart-contracts/exchange#burn-1'>burn</Link>.
+Emitted each time a transfer occurs via [transfer](#transfer-1), [transferFrom](#transferfrom), <Link to='/docs/v2/smart-contracts/pair/#mint-1'>mint</Link>, or <Link to='/docs/v2/smart-contracts/pair/#burn-1'>burn</Link>.
 
 # Read-Only Functions
 


### PR DESCRIPTION
With this pull request I fix most of the broken links in your docs, with a few caveats:

- in [how uniswap works](https://uniswap.org/docs/v2/protocol-overview/how-uniswap-works) there was a broken link to https://uniswap.org/docs/v2/core-concepts/math , now it points to [advanced topics math](https://uniswap.org/docs/v2/advanced-topics/math/) which is a placeholder for the whitepaper. Given how much exposure it's getting, I suggest reworking the target page or change the target to something like [advanced topics understanding returns](https://uniswap.org/docs/v2/advanced-topics/understanding-returns/) .
- as per #132 I was unsure about the intended target of https://uniswap.org/docs/v2/technical-considerations/pair-addresses , so no action was taken.
- check if the modified relative link in [v1 frontend integration pool liquidity](https://uniswap.org/docs/v1/frontend-integration/pool-liquidity/)  works for your pipeline.

Of course I warmly suggest adopting a tool for checking broken links in your continuous integration process. ;)