### PR TITLE
Fix formatting in 01-how-uniswap-works.md

### DIFF
--- a/src/pages/docs/v2/01-protocol-overview/01-how-uniswap-works.md
+++ b/src/pages/docs/v2/01-protocol-overview/01-how-uniswap-works.md
@@ -5,8 +5,7 @@ tags: protocol-overview, documentation
 
 ![](/images/anatomy.jpg)
 
-Uniswap is an _automated liquidity protocol_ powered by a 
-<Link to="/docs/v2/protocol-overview/glossary/#constant-product-formula">constant product formula</Link> 
+Uniswap is an _automated liquidity protocol_ powered by a <Link to="/docs/v2/protocol-overview/glossary/#constant-product-formula">constant product formula</Link>
 and implemented in a system of non-upgradeable smart contracts on the [Ethereum](https://ethereum.org/) blockchain. 
 It obviates the need for trusted intermediaries, prioritizing **decentralization**, **censorship resistance**, 
 and **security**. Uniswap is **open-source software** licensed under the


### PR DESCRIPTION
Putting `<Link>` on a new line seems to have broken markdown.

Before (image):

![image](https://user-images.githubusercontent.com/7571518/92015805-9c61a400-ed51-11ea-9bc2-d6149c58c4f6.png)

After (image):

![image](https://user-images.githubusercontent.com/7571518/92015852-b8654580-ed51-11ea-8529-2c67a8291d55.png)