### PR TITLE
Fix typos

### DIFF
--- a/src/pages/blog/01-uniswap-history/index.md
+++ b/src/pages/blog/01-uniswap-history/index.md
@@ -34,7 +34,7 @@ On July 6th, 2017 I was laid off from my first job out of college, working as a 
 
 > **Hayden**: Okay…
 
-Catching me at a low point, Karl convinced me to accept Ethereum into my life. I was determined to give it a shot, and spent the next two months learning the basics of Ethereum, Solidity, and Javascript.
+Catching me at a low point, Karl convinced me to accept Ethereum into my life. I was determined to give it a shot, and spent the next two months learning the basics of Ethereum, Solidity, and JavaScript.
 
 In order to expand my skillset, I decided it was time to work on a “real” project. At Karl’s suggestion I decided to implement an automated market maker, as described by Vitalik in [this reddit post](https://www.reddit.com/r/ethereum/comments/55m04x/lets_run_onchain_decentralized_exchanges_the_way/) and [this blogpost](https://vitalik.ca/general/2017/06/22/marketmakers.html).
 

--- a/src/pages/blog/06-ipfs-uniswap-interface/index.md
+++ b/src/pages/blog/06-ipfs-uniswap-interface/index.md
@@ -42,7 +42,7 @@ Our team has always cared about decentralization, security, and accessibility. T
 [open-source interface](https://github.com/Uniswap/uniswap-interface) for Uniswap that the community can directly run,
 verify and build upon. We’ve just taken another step forward by decentralizing the hosting of the Uniswap Interface using IPFS.
 
-Using [Github Actions](https://github.com/features/actions), the [Uniswap Interface](https://github.com/Uniswap/uniswap-interface)
+Using [GitHub Actions](https://github.com/features/actions), the [Uniswap Interface](https://github.com/Uniswap/uniswap-interface)
 is now deployed at least once per day to IPFS. Each release is automatically [pinned](https://docs.ipfs.io/concepts/persistence/)
 using [pinata.cloud](https://pinata.cloud), a free IPFS pinning service.
 The IPFS releases can be found [on GitHub](https://github.com/Uniswap/uniswap-interface/releases).

--- a/src/pages/docs/v1/index.md
+++ b/src/pages/docs/v1/index.md
@@ -32,7 +32,7 @@ This site will serve as a project overview for Uniswap - explaining how it works
 # Resources
 
 - [Website](https://uniswap.org)
-- [Github](https://github.com/Uniswap)
+- [GitHub](https://github.com/Uniswap)
 - [Twitter](https://twitter.com/UniswapProtocol)
 - [Reddit](https://www.reddit.com/r/Uniswap)
 - [Email](mailto:contact@uniswap.org)

--- a/src/pages/docs/v2/05-javascript-SDK/01-quick-start.md
+++ b/src/pages/docs/v2/05-javascript-SDK/01-quick-start.md
@@ -7,7 +7,7 @@ The Uniswap SDK exists to help developers build on top of Uniswap. It's designed
 
 # Installation
 
-The easiest way to consume the SDK is via NPM. To install it in your project, simply run `yarn add @uniswap/sdk` (or `npm install @uniswap/sdk`).
+The easiest way to consume the SDK is via npm. To install it in your project, simply run `yarn add @uniswap/sdk` (or `npm install @uniswap/sdk`).
 
 # Usage
 

--- a/src/pages/docs/v2/05-javascript-SDK/05-getting-pair-addresses.md
+++ b/src/pages/docs/v2/05-javascript-SDK/05-getting-pair-addresses.md
@@ -26,7 +26,7 @@ Thanks to some [fancy footwork in the factory](https://github.com/Uniswap/uniswa
 
 ## Examples
 
-### Typescript
+### TypeScript
 
 This example makes use of the <Link to='docs/v2/SDK/getting-started'>Uniswap SDK</Link>. In reality, the SDK computes pair addresses behind the scenes, obviating the need to compute them manually like this.
 

--- a/src/pages/docs/v2/06-smart-contract-integration/01-quick-start.md
+++ b/src/pages/docs/v2/06-smart-contract-integration/01-quick-start.md
@@ -27,10 +27,10 @@ cd demo
 npx truffle init
 ```
 
-## Setting up NPM
+## Setting up npm
 
-In order to reference the Uniswap V2 contracts, you should use the NPM artifacts we deploy containing the core and
-periphery smart contracts and interfaces. To add npm dependencies, we first initialize the NPM package. 
+In order to reference the Uniswap V2 contracts, you should use the npm artifacts we deploy containing the core and
+periphery smart contracts and interfaces. To add npm dependencies, we first initialize the npm package. 
 We can run `npm init` in the same directory to create a `package.json` file. You can accept all the defaults and
 change it later.
 
@@ -40,7 +40,7 @@ npm init
 
 ## Adding dependencies
 
-Now that we have an NPM package, we can add our dependencies. Let's add both the 
+Now that we have an npm package, we can add our dependencies. Let's add both the 
 [`@uniswap/v2-core`](https://www.npmjs.com/package/@uniswap/v2-core) and 
 [`@uniswap/v2-periphery`](https://www.npmjs.com/package/@uniswap/v2-periphery) packages.
 

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -36,7 +36,7 @@ const menu = [
         name: 'Documentation',
         link: '/docs/v2'
       },
-      { name: 'Github', link: 'https://github.com/Uniswap' },
+      { name: 'GitHub', link: 'https://github.com/Uniswap' },
       { name: 'Whitepaper', link: '/whitepaper.pdf' },
       { name: 'Audit', link: '/audit.html' },
       { name: 'Bug Bounty', link: '/bug-bounty' }


### PR DESCRIPTION
Just a few minor typo/capitalization fixes, e.g.: `Github` -> `GitHub`, `Javascript` -> `JavaScript`, etc.