### PR TITLE
Token entity doesn not have field allPair

### DIFF
--- a/src/pages/docs/v2/10-API/03-queries.md
+++ b/src/pages/docs/v2/10-API/03-queries.md
@@ -165,9 +165,6 @@ The allPairs field gets the first 200 pairs DAI is included in sorted by liquidi
    derivedETH
    tradeVolumeUSD
    totalLiquidity
-   allPairs(first: 200, orderBy: reserveUSD, orderDirection: desc) {
-     reserveUSD
-   }
  }
 }
 ```


### PR DESCRIPTION
For updating page here:
https://uniswap.org/docs/v2/API/queries/
Section: Token Overview

Token entity doesn't seem to have field "allPair".