### PR TITLE
The `pair_in` parameter is expected to be `[String!]`

### DIFF
--- a/src/pages/docs/v2/10-API/03-queries.md
+++ b/src/pages/docs/v2/10-API/03-queries.md
@@ -202,7 +202,7 @@ allPairs = [
 ```
 
 ```
-query($allPairs: [Bytes]!) {
+query($allPairs: [String!]) {
  mints(first: 30, where: { pair_in: $allPairs }, orderBy: timestamp, orderDirection: desc) {
    transaction {
      id


### PR DESCRIPTION
The runtime error was:
```
Variable '$pairs' of type '[String]!' used in position expecting type '[String!]'
```