### PR TITLE
Unify pragma notations

### DIFF
--- a/src/pages/docs/v2/06-smart-contract-integration/01-quick-start.md
+++ b/src/pages/docs/v2/06-smart-contract-integration/01-quick-start.md
@@ -79,7 +79,7 @@ touch contracts/LiquidityValueCalculator.sol
 This will be the interface of the contract we implement. Put it in `contracts/interfaces/ILiquidityValueCalculator.sol`.
 
 ```solidity
-pragma solidity =0.6.6;
+pragma solidity ^0.6.6;
 
 interface ILiquidityValueCalculator {
     function computeLiquidityShareValue(uint liquidity, address tokenA, address tokenB) external returns (uint tokenAAmount, uint tokenBAmount);
@@ -95,7 +95,7 @@ but since we need to unit test the contract it should be an argument. You can us
 when accessing this variable.
 
 ```solidity
-pragma solidity =0.6.6;
+pragma solidity ^0.6.6;
 
 import './interfaces/ILiquidityValueCalculator.sol';
 
@@ -118,7 +118,7 @@ Let's put this in a separate function. To implement it, we must:
 The [`UniswapV2Library`](/docs/v2/smart-contracts/library/) has some helpful methods for this.
 
 ```solidity
-pragma solidity =0.6.6;
+pragma solidity ^0.6.6;
 
 import '@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol';
 import '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
@@ -136,7 +136,7 @@ contract LiquidityValueCalculator is ILiquidityValueCalculator {
 Finally we just need to compute the share value. We will leave that as an exercise to the reader.
 
 ```solidity
-pragma solidity =0.6.6;
+pragma solidity ^0.6.6;
 
 import './interfaces/ILiquidityValueCalculator.sol';
 import '@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol';


### PR DESCRIPTION
There is no need to restrict the version to this specific version. Letting users choose the version more freely makes integrations easier.