### PR TITLE
smart-contract-integration/quick-start imports fix

### DIFF
--- a/src/pages/docs/v2/06-smart-contract-integration/01-quick-start.md
+++ b/src/pages/docs/v2/06-smart-contract-integration/01-quick-start.md
@@ -120,6 +120,7 @@ The [`UniswapV2Library`](/docs/v2/smart-contracts/library/) has some helpful met
 ```solidity
 pragma solidity ^0.6.6;
 
+import './interfaces/ILiquidityValueCalculator.sol';
 import '@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol';
 import '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
 


### PR DESCRIPTION
One of examples in the article have missing import of interface for the contract.