### PR TITLE
Adds totalSupply field to Pair Day Data section

### DIFF
--- a/src/pages/docs/v2/10-API/02-entities.md
+++ b/src/pages/docs/v2/10-API/02-entities.md
@@ -218,6 +218,7 @@ Tracks pair data across each day.
 | dailyVolumeToken1 | BigDecimal | total amount of token1 swapped throughout day                                                    |
 | dailyVolumeUSD    | BigDecimal | total volume within pair throughout day                                                          |
 | dailyTxns         | BigInt     | amount of transactions on pair throughout day                                                    |
+| totalSupply       | BigDecimal | total supply of liquidity token distributed to LPs                                               |
 
 ### TokenDayData
 


### PR DESCRIPTION
totalSupply is part of the "Pair Day Data" entity but is missing from the docs