### PR TITLE
Spacing tweaks

### DIFF
--- a/src/components/wizard.js
+++ b/src/components/wizard.js
@@ -114,7 +114,7 @@ const StyledWizard = styled.div`
 const CardWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  justify-content: flex-start;
   flex-wrap: wrap;
   /* padding: 1.5rem; */
   /* overflow-x: scroll;

--- a/src/components/wizard.js
+++ b/src/components/wizard.js
@@ -114,7 +114,7 @@ const StyledWizard = styled.div`
 const CardWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: flex-start;
+  justify-content: space-around;
   flex-wrap: wrap;
   /* padding: 1.5rem; */
   /* overflow-x: scroll;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -161,32 +161,29 @@ const StyledSectionFlex = styled.div`
 `
 
 const StyledItemRow = styled.nav`
-  box-sizing: border-box;
+  align-items: center;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   flex-wrap: wrap;
-  /* gap: 12px; */
-  transition: right 0.25s ease;
-  margin-top: 0.5rem;
-
-  > * + * {
-    margin-left: 12px;
+  margin: 0rem;
+  width: 100%;
+  & > *:not(:first-of-type) {
+    margin-top: 12px;
   }
-
-  @media (max-width: 960px) {
-    align-items: center;
-    width: 100%;
-    margin: 0rem;
-    /* gap: 12px; */
-    /* flex-direction: column; */
-
-    > * + * {
-      margin: 0rem;
-      margin-top: 12px;
+  @media (min-width: 640px) {
+    flex-direction: row;
+    justify-content: center;
+    & > * {
+      margin-bottom: 12px;
+    }
+    & > *:not(:first-of-type) {
+      margin-top: 0;
+      margin-left: 12px;
     }
   }
-  @media (max-width: 640px) {
-    /* align-items: flex-start; */
+  @media (min-width: 960px) {
+    box-sizing: border-box;
+    transition: right 0.25s ease;
   }
 `
 


### PR DESCRIPTION
## Tweaks responsive margin logic  for `StyledItemRow`
I switched this around to do a progressive step-up from  mobile,  and to explicitly defined `flex-direction: column` at those sizes. I addressed the safari `gap` gap (lol) by modifying margin as the  possible layouts change.

### Before
![image](https://user-images.githubusercontent.com/5773490/106396282-f3d57000-63d4-11eb-8edf-54394b5d9d9c.png)
![image](https://user-images.githubusercontent.com/5773490/106396302-0bacf400-63d5-11eb-9337-3b42b9306460.png)

### After
![image](https://user-images.githubusercontent.com/5773490/106396285-f932ba80-63d4-11eb-8951-cbd7dacbb970.png)
![image](https://user-images.githubusercontent.com/5773490/106396308-12d40200-63d5-11eb-9793-ecb6c4db9122.png)


## Adjusts spacing on docs cards.
These were leaving more space on the right side in some screen sizes. Using space-around will  spread the content out to fill it more evenly.

### Before
![image](https://user-images.githubusercontent.com/5773490/106396095-d5bb4000-63d3-11eb-8f10-024e1290be26.png)

### After
![image](https://user-images.githubusercontent.com/5773490/106396061-ab698280-63d3-11eb-85b4-dde4535ccb43.png)
