### PR TITLE
improvement: Make header links accessible by allowing you to tab through them

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -200,51 +200,9 @@ const StyledDescription = styled.p`
 `
 
 export default function Menu(props) {
-  const matches = useMediaQuery('only screen and (max-width: 960px)')
-  const node = useRef()
-  const [isOpen, updateIsOpen] = useState(matches)
-
-  useEffect(() => {
-    const handleClickOutside = e => {
-      if (node.current.contains(e.target)) {
-        return
-      }
-      updateIsOpen(false)
-    }
-
-    const onFocus = focused => {
-      if (focused) {
-        updateIsOpen(true)
-      } else {
-        updateIsOpen(false)
-      }
-    }
-
-    if (isOpen && !matches) {
-      node.current.removeEventListener('focusin', () => onFocus(false))
-      node.current.removeEventListener('focusout', () => onFocus(false))
-      document.addEventListener('mouseover', handleClickOutside)
-    } else {
-      node.current.addEventListener('focusin', () => onFocus(true))
-      node.current.addEventListener('focusout', () => onFocus(false))
-      document.removeEventListener('mouseover', handleClickOutside)
-    }
-
-    return () => {
-      document.removeEventListener('mouseover', handleClickOutside)
-      node.current.removeEventListener('focusin', () => onFocus(false))
-      node.current.removeEventListener('focusout', () => onFocus(false))
-    }
-  }, [isOpen, updateIsOpen, matches])
-
   return (
-    <StyledMenu ref={node} tabIndex={0}>
+    <StyledMenu tabIndex={0}>
       <StyledMenuTitle
-        onMouseOver={() => updateIsOpen(true)}
-        onFocus={() => {
-          updateIsOpen(true)
-        }}
-        isOpen={isOpen}
       >
         <span style={{ marginRight: '0.25rem' }}>{props.data.name} </span>
         

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -50,18 +50,22 @@ const StyledMenu = styled.button`
   }
 `
 
-const MenuFlyout = styled.span`
+const MenuFlyout = styled.nav`
   border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
   position: absolute;
-  top: 1.75rem;
+  top: 1.65rem;
   left: -1rem;
   min-width: 256px;
   width: 100%;
   width: fit-content;
-  padding: 1rem 1.5rem;
   border-radius: 8px;
+  height: 0;
+  width: 0;
+  overflow: hidden;
+  transition: max-height 0.4s 2s, opacity 0.4s;
+
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.04), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
     0px 24px 32px rgba(0, 0, 0, 0.04);
   z-index: 999;
@@ -82,6 +86,8 @@ const MenuFlyout = styled.span`
     margin-top: 1rem;
     backdrop-filter: 'none';
     background-color: rgba(255, 255, 255, 0);
+    width: auto;
+    height: auto;
   }
 `
 
@@ -93,11 +99,29 @@ const StyledMenuTitle = styled.span`
   font-family: 'GT Haptik Regular';
   width: fit-content;
   font-size: 16px;
+  padding: 0 0 0.2rem;
+  :focus {
+    outline: 0;
+    
+  }
+  a:focus {
+    opacity: 0.5;
+  }
 
   cursor: pointer;
   :hover {
     color: ${({ theme }) => theme.colors.grey7};
   }
+
+  :hover nav, &:focus-within nav, nav:hover {
+    width: auto;
+    height: auto;
+    max-height: 1500px;
+    padding: 1rem;
+    opacity: 1;
+    transition: max-height 0.4s 3s;
+  }
+
   @media (max-width: 960px) {
     margin-bottom: 1rem;
     user-select: none;
@@ -132,6 +156,10 @@ const StyledExternalLink = styled.a`
   margin: 0.25rem 0;
   width: 100%;
   cursor: pointer;
+  :focus {
+    outline: 0;
+    opacity: 0.9;
+  }
   :hover {
     * {
       color: ${({ theme }) => theme.colors.grey5};
@@ -219,7 +247,7 @@ export default function Menu(props) {
         isOpen={isOpen}
       >
         <span style={{ marginRight: '0.25rem' }}>{props.data.name} </span>
-        {isOpen ? (
+        
           <MenuFlyout>
             {props.data.sublinks.map((item, index) => {
               return (
@@ -239,9 +267,6 @@ export default function Menu(props) {
               )
             })}
           </MenuFlyout>
-        ) : (
-          ''
-        )}
       </StyledMenuTitle>
     </StyledMenu>
   )


### PR DESCRIPTION
I noticed that subsections in the header are not in the DOM until their parent link is 'hovered' (actually an event listener). 

This is a bit peak for people who rely on tabbing to navigate websites, or use screen-readers to read the full contents of the page, as they may not always have the necessary inputs to fire off an event listener. This stuff can all be done super easily through CSS, without using eventListeners or removing nodes from the DOM.

Quite a small change and you may not even merge it but if anything is worth my time, it is accessibility :) 