### PR TITLE
Documentation button link to v3 #277

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -361,8 +361,8 @@ const IndexPage = props => {
             </Button>
             <Button
               outlined
-              to="/docs"
-              as={Link}
+              target="_blank"
+              href="https://docs.uniswap.org/"
               style={{
                 fontSize: '20px'
               }}


### PR DESCRIPTION
Redirected the documentation button to V3 as requested in #277 