### PR TITLE
redirected documentation button

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -361,13 +361,13 @@ const IndexPage = props => {
             </Button>
             <Button
               outlined
-              to="/docs"
-              as={Link}
+              target="_blank"
+              href="https://docs.uniswap.org/"
               style={{
                 fontSize: '20px'
               }}
             >
-              Documentation
+              Documentation 
             </Button>
             <Button
               outlined


### PR DESCRIPTION
Fixed the documentation button link from https://uniswap.org/docs/v2  Url to this  https://docs.uniswap.org/